### PR TITLE
Update infrastructure to reflect changes to waku_rpc

### DIFF
--- a/ansible/roles/nim-waku/tasks/consul.yml
+++ b/ansible/roles/nim-waku/tasks/consul.yml
@@ -4,7 +4,7 @@
     url: 'http://localhost:{{ nim_waku_rpc_tcp_port }}/'
     method: POST
     body: 
-      method: 'waku_info'
+      method: 'get_waku_v2_debug_v1_info'
       params: []
       id: 1
     status_code: 200
@@ -23,7 +23,7 @@
         address: '{{ nim_waku_p2p_tcp_port }}'
         tags: ['{{ env }}.{{ stage }}', 'nim', 'waku']
         meta:
-          node_enode: '{{ waku_info.json.result | default("unknown") }}'
+          node_enode: '{{ waku_info.json.result.listenStr | default("unknown") }}'
         checks:
           - name: '{{ nim_waku_cont_name }}-health'
             type: 'tcp'
@@ -49,4 +49,4 @@
         checks:
           - id: '{{ nim_waku_cont_name }}-rpc-health'
             type: script
-            script: 'curl -s -X POST -H Content-type:application/json --data {"jsonrpc":"2.0","method":"waku_info","params":[],"id":1} http://localhost:{{ nim_waku_rpc_tcp_port }}/'
+            script: 'curl -s -X POST -H Content-type:application/json --data {"jsonrpc":"2.0","method":"get_waku_v2_debug_v1_info","params":[],"id":1} http://localhost:{{ nim_waku_rpc_tcp_port }}/'


### PR DESCRIPTION
The `nim-waku` repo had some recent changes that may affect the cluster infrastructure.

Specifically, the RPC API was updated to a REST(like) JSON-RPC API, with the following changes:
1. The `waku_info` method was renamed to `get_waku_v2_debug_v1_info`.
2. The response to (1) now nests the advertised node address in the `listenStr` property of the result object (i.e. `waku_info.json.result` now becomes `waku_info.json.result.listenStr`).

We've also merged a [fix](https://github.com/status-im/nim-waku/pull/348) for the [issue](https://github.com/status-im/nim-waku/issues/339) where `waku_info` failed to return the correct public IP address.

This PR hopefully addresses the above - let me know if I'm missing anything important.