### PR TITLE
Enable Admin API for Waku v2 cluster nodes

### DIFF
--- a/ansible/roles/nim-waku/tasks/compose.yml
+++ b/ansible/roles/nim-waku/tasks/compose.yml
@@ -34,6 +34,7 @@
             --relay=true
             --filter=true
             --dbpath=/data
+            --rpc-admin=true
             {% else %}
             --discovery={{ nim_waku_discovery_enabled }}
             {% endif %}
@@ -42,7 +43,6 @@
             --log-level={{ nim_waku_log_level }}
             --rpc-port={{ nim_waku_rpc_tcp_port }}
             --rpc-address=0.0.0.0
-            --rpc-admin=true
             --tcp-port={{ nim_waku_p2p_tcp_port }}
             --udp-port={{ nim_waku_p2p_udp_port }}
             --metrics-server={{ nim_waku_metrics_enabled }}

--- a/ansible/roles/nim-waku/tasks/compose.yml
+++ b/ansible/roles/nim-waku/tasks/compose.yml
@@ -42,6 +42,7 @@
             --log-level={{ nim_waku_log_level }}
             --rpc-port={{ nim_waku_rpc_tcp_port }}
             --rpc-address=0.0.0.0
+            --rpc-admin=true
             --tcp-port={{ nim_waku_p2p_tcp_port }}
             --udp-port={{ nim_waku_p2p_udp_port }}
             --metrics-server={{ nim_waku_metrics_enabled }}


### PR DESCRIPTION
To establish peering between cluster nodes (https://github.com/status-im/nim-waku/issues/408), a JSON-RPC `method` was added to the Admin API that allows for adding new peers to a node on an ad-hoc basis. This requires the Admin API to be enabled on Waku v2 node.

Added Admin API method: `post_waku_v2_admin_v1_peers`

