### PR TITLE
Enable peer persistence on cluster nodes

### DIFF
--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -32,6 +32,7 @@ services:
       --filter=true
       --dbpath=/data
       --rpc-admin=true
+      --peerpersist=true
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}


### PR DESCRIPTION
This PR enables peer persistence for Waku v2 cluster nodes.

This was recently [made optional](https://github.com/status-im/nim-waku/blob/d375dc0422dd0c0b786971b4bfa8ccc42684090a/waku/v2/node/config.nim#L46-L49) and disabled by default.