### PR TITLE
Enable keep-alive on cluster nodes

### DIFF
--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -33,6 +33,7 @@ services:
       --dbpath=/data
       --rpc-admin=true
       --peerpersist=true
+      --keep-alive=true
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}


### PR DESCRIPTION
This PR fixes https://github.com/status-im/nim-waku/issues/504 and addresses https://github.com/status-im/nim-waku/issues/487

It enables configuration for Waku v2 cluster nodes that will keep idle connections alive. I have deployed the necessary `nim-waku` changes to both the `prod` and `test` cluster.