### PR TITLE
Enable persisting messages in store nodes

### DIFF
--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -34,6 +34,7 @@ services:
       --rpc-admin=true
       --peerpersist=true
       --keep-alive=true
+      --persist-messages=true
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}


### PR DESCRIPTION
1. A recent change in the DB Schema requires dropping the `Message` table within the `--dbpath` directory for wakuv2 fleet nodes (`prod` and `test`):

```
#!/bin/bash
sqlite3  $1 "DROP TABLE IF EXISTS Message;" .quit
```

2. _Thereafter_, this new config option, `--persist-messages=true` should be applied on `prod` and `test`.

@staheri14, perhaps you could confirm the above steps?