### PR TITLE
Use new, consistent config items

### DIFF
--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -30,9 +30,9 @@ services:
       --store=true
       --relay=true
       --filter=true
-      --dbpath=/data
+      --db-path=/data
       --rpc-admin=true
-      --peerpersist=true
+      --persist-peers=true
       --keep-alive=true
       --persist-messages=true
 {% else %}


### PR DESCRIPTION
Brings config items in line with consistency changes in https://github.com/status-im/nim-waku/pull/543

This is done in a backwards-compatible way to support both versions of config items in the interim.