### PR TITLE
Enable lightpush on cluster nodes

### DIFF
--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -41,6 +41,7 @@ services:
       --persist-peers=true
       --keep-alive=true
       --persist-messages=true
+      --lightpush=true
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}


### PR DESCRIPTION
Enables `lightpush` protocol on cluster nodes. @jakubgs will it be possible to apply this config only to `test` nodes and not (yet) `prod`?

cc @oskarth 