### PR TITLE
fix nim_waku_random_node_key generation

### DIFF
--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -9,8 +9,6 @@ nim_waku_node_db_path: '{{ nim_waku_cont_vol }}/data'
 
 # Value for private node key which is used to create public enode key
 nim_waku_node_key: ~
-# Node key needs to be a 64 char hexadecimal string, used if not provided
-nim_waku_random_node_key: '{{ ansible_date_time.epoch | random | hash("sha256") }}'
 nim_waku_node_key_file_path: '{{ nim_waku_cont_vol }}/nodekey'
 
 # WARNING: Enabling this will disable relaying of messages

--- a/ansible/roles/nim-waku/tasks/nodekey.yml
+++ b/ansible/roles/nim-waku/tasks/nodekey.yml
@@ -11,6 +11,13 @@
     path: '{{ nim_waku_node_key_file_path }}'
   register: key_file
 
+- name: Generate random node key
+  throttle: 1
+  set_fact:
+    # Node key needs to be a 64 char hexadecimal string
+    nim_waku_random_node_key: '{{ ansible_date_time.epoch | random | hash("sha256") }}'
+  when: not key_file.stat.exists
+
 - name: Save generate node key to file
   copy:
     dest: '{{ nim_waku_node_key_file_path | mandatory }}'


### PR DESCRIPTION
The `nim_waku_random_node_key` was not randomly generated. The variable was initialized once with a random key and then used for all hosts. This lead to 2 nodes in the prod fleet having the same key, which caused errors.

This PR fixes it by generating the key using `set_fact`.

Tested on `node-01.ac-cn-hongkong-c.wakuv2.test` and works fine