### PR TITLE
Enable Swap Protocol in Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.tfstate.backup
 *.retry
 ansible/files/*
+.vscode

--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -2,6 +2,7 @@
 # Tag dependent on fleet: test, prod
 nim_waku_cont_tag: 'deploy-v2-{{ stage }}'
 nim_waku_cont_name: 'nim-waku-v2'
+nim_waku_swap_protocol_enabled: false
 
 nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -2,6 +2,7 @@
 # Tag dependent on fleet: test, prod
 nim_waku_cont_tag: 'deploy-v2-{{ stage }}'
 nim_waku_cont_name: 'nim-waku-v2'
+nim_waku_swap_protocol_enabled: true
 
 nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303

--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -14,7 +14,8 @@ nim_waku_node_key_file_path: '{{ nim_waku_cont_vol }}/nodekey'
 # WARNING: Enabling this will disable relaying of messages
 nim_waku_light_node_enabled: false
 
-# Default value to Indicate if the swap Protocol will be enabled
+# The swap protocol keeps track of the accounting state for each peer. 
+# Enabling this will display logs from the swap protocol.
 nim_waku_swap_protocol_enabled: true
 
 # Available: error, warn, info, debug

--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -14,6 +14,9 @@ nim_waku_node_key_file_path: '{{ nim_waku_cont_vol }}/nodekey'
 # WARNING: Enabling this will disable relaying of messages
 nim_waku_light_node_enabled: false
 
+# Default value to Indicate if the swap Protocol will be enabled
+nim_waku_swap_protocol_enabled: true
+
 # Available: error, warn, info, debug
 nim_waku_log_level: 'info'
 

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -42,7 +42,7 @@ services:
       --keep-alive=true
       --persist-messages=true
       --lightpush=true
-      --swap=true
+      --swap={{ nim_waku_swap_protocol_enabled | lower }}
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -42,6 +42,7 @@ services:
       --keep-alive=true
       --persist-messages=true
       --lightpush=true
+      --swap=true
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}


### PR DESCRIPTION
Enable Swap Protocol in Dockercompose. 
This is to ensure that the swap protocol is mounted and the logs are clearly visible on Kibana.

closes #15 