### PR TITLE
open ports for chat2bridge deployment

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -29,3 +29,5 @@ open_ports_list:
   - { port: '{{ nim_waku_p2p_udp_port }}',         protocol: 'udp' }
   - { port: '{{ nim_waku_websockify_cont_port }}', protocol: 'tcp' }
   - { port: '80', comment: 'Certbot verification', protocol: 'tcp' }
+  - { port: '9000', comment: 'chat2bridge',        protocol: 'tcp' }
+  - { port: '9000', comment: 'chat2bridge',        protocol: 'udp' }

--- a/ansible/host_vars/node-01.do-ams3.wakuv2.prod.yml
+++ b/ansible/host_vars/node-01.do-ams3.wakuv2.prod.yml
@@ -4,12 +4,12 @@ matterbridge_bridges:
     status:
       Token: '{{lookup("passwordstore", "cloud/Discord/auto/token")}}'
       Server: 'Status'
-      RemoteNickFormat: '{NICK}@{PROTOCOL}'
+      RemoteNickFormat: '{NICK}@chat2'
 
   api.chat2:
     BindAddress: "0.0.0.0:4242"
     Buffer: 1000
-    RemoteNickFormat: "{NICK}@chat2"
+    RemoteNickFormat: "{NICK}@{PROTOCOL}"
 
 matterbridge_gateways:
   - { status: "waku", discord: [{ srv: "status", ch: "waku" }], api: ["chat2"], private: true }

--- a/hosts.tf
+++ b/hosts.tf
@@ -20,5 +20,6 @@ module "nim_hosts" {
     "80",    /* certbot */
     "443",   /* p2p websocket */
     "30303", /* p2p main */
+    "9000",  /* chat2bridge */
   ]
 }


### PR DESCRIPTION
chat2bridge is a waku node that runs on port 9000. Other nodes connect to this
node and we need to open port 9000.
