### PR TITLE
Fix random nodekey generation for nim-waku

### DIFF
--- a/ansible/roles/nim-waku/tasks/nodekey.yml
+++ b/ansible/roles/nim-waku/tasks/nodekey.yml
@@ -15,7 +15,7 @@
   throttle: 1
   set_fact:
     # Node key needs to be a 64 char hexadecimal string
-    nim_waku_random_node_key: '{{ ansible_date_time.epoch | random | hash("sha256") }}'
+    nim_waku_random_node_key: '{{ lookup("password", "/dev/null") | hash("sha256") }}'
   when: not key_file.stat.exists
 
 - name: Save generate node key to file


### PR DESCRIPTION
The `random` function in ansible/jinja will pick a random number from a
list. In the current code:

```
ansible_date_time.epoch | random
```

Will pick a random number from the current timestamp. For example:

```
ok: [node-01.ac-cn-hongkong-c.wakuv2.test] => {
    "ansible_facts": {
        "nim_waku_random_node_key": "7"
    },
    "changed": false
}
```

The current timestamp is `1622800227`, so there's a high change the
"random" number is 1, 6, 2, 8, ....

I've changed it to use the ansible.builtin.password
(https://docs.ansible.com/ansible/2.10/collections/ansible/builtin/password_lookup.html) instead which according to the docs is used to generate random passwords.

I've confirmed this works by running it several times on a host and it
always generated a new random hash.
