### PR TITLE
Enable websocket config in fleets

### DIFF
--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -12,13 +12,21 @@ nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303
 nim_waku_metrics_port: 8008
 
+# Enable websockets in Waku
+nim_waku_websocket_enabled: true
+nim_waku_websocket_cont_port: 8000
+nim_waku_websocket_domain: '{{ dns_entry }}'
+nim_waku_websocket_ssl_dir: '/etc/letsencrypt'
+nim_waku_websocket_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/fullchain.pem'
+nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/privkey.pem'
+
 # Enable WebSockets via Websockify
 nim_waku_websockify_enabled: true
 nim_waku_websockify_cont_port: 443
-nim_waku_websockify_domain: '{{ dns_entry }}'
-nim_waku_websockify_ssl_dir: '/etc/letsencrypt'
-nim_waku_websockify_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websockify_domain }}/fullchain.pem'
-nim_waku_websockify_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websockify_domain }}/privkey.pem'
+nim_waku_websockify_domain: '{{ nim_waku_websocket_domain }}'
+nim_waku_websockify_ssl_dir: '{{ nim_waku_websocket_ssl_dir }}'
+nim_waku_websockify_ssl_cert: '{{ nim_waku_websocket_ssl_cert }}'
+nim_waku_websockify_ssl_key: '{{ nim_waku_websocket_ssl_key }}'
 
 # LetsEncrypt via Certbot
 certbot_docker_enabled: true

--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -66,3 +66,11 @@ consul_url: 'http://localhost:8500/v1/catalog'
 compose_recreate: 'smart'
 compose_state: 'present'
 compose_restart: false
+
+#websocket config in nim waku
+nim_waku_websocket_enabled: false
+nim_waku_websocket_cont_port: 8000
+#nim_waku_websocket_domain: 'hostname.example.org'
+#nim_waku_websocket_ssl_dir: '/etc/letsencrypt'
+#nim_waku_websocket_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/fullchain.pem'
+#nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/privkey.pem'

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -18,11 +18,15 @@ services:
         condition: '{{ nim_waku_restart_condition }}'
     volumes:
       - '{{ nim_waku_node_db_path }}:/data'
+{% if nim_waku_websocket_enabled %}
+      - '{{ nim_waku_websocket_ssl_dir }}:{{ nim_waku_websocket_ssl_dir | mandatory }}'
+{% endif %}
     ports:
       - '{{ nim_waku_rpc_tcp_addr }}:{{ nim_waku_rpc_tcp_port }}:{{ nim_waku_rpc_tcp_port }}/tcp'
       - '{{ nim_waku_p2p_tcp_port }}:{{ nim_waku_p2p_tcp_port }}/tcp'
       - '{{ nim_waku_p2p_udp_port }}:{{ nim_waku_p2p_udp_port }}/udp'
       - '{{ nim_waku_metrics_port }}:{{ nim_waku_metrics_port }}/tcp'
+      - '{{ nim_waku_websocket_cont_port }}:{{ nim_waku_websocket_cont_port }}/tcp'
     healthcheck:
       test: ["CMD", "wget", "-qO-", "--header", "Content-type:application/json",
         "--post-data", "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\": \"get_waku_v2_debug_v1_info\",\"params\":[]}",
@@ -41,6 +45,12 @@ services:
       --persist-messages=true
       --lightpush=true
       --swap={{ nim_waku_swap_protocol_enabled | lower }}
+{% if nim_waku_websocket_enabled %}
+      --websocket-secure-support=true
+      --websocket-secure-key-path={{ nim_waku_websocket_ssl_key }}
+      --websocket-secure-cert-path={{ nim_waku_websocket_ssl_cert }}
+      --websocket-port={{ nim_waku_websocket_cont_port }} 
+{% endif %}
 {% else %}
       --discovery={{ nim_waku_discovery_enabled }}
 {% endif %}


### PR DESCRIPTION
This PR introduces the config changes required to enable secure web-sockets to resolve the issue https://github.com/status-im/nim-waku/issues/434. 

We add 4 configs to the nim-waku build in this PR.

- websocket-secure-support
- websocket-secure-key-path
- websocket-secure-cert-path
- websocket-port