### PR TITLE
Configure fleet max connections

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -10,6 +10,8 @@ nim_waku_metrics_port: 8008
 nim_waku_rpc_tcp_port: 8545
 nim_waku_rpc_tcp_addr: 0.0.0.0
 
+nim_waku_max_connections: 150
+
 # Enable WebSockets via Websockify
 nim_waku_websockify_enabled: true
 nim_waku_websockify_cont_port: 443

--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -10,7 +10,7 @@ nim_waku_metrics_port: 8008
 nim_waku_rpc_tcp_port: 8545
 nim_waku_rpc_tcp_addr: 0.0.0.0
 
-nim_waku_max_connections: 150
+nim_waku_p2p_max_connections: 150
 
 # Enable WebSockets via Websockify
 nim_waku_websockify_enabled: true

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -13,7 +13,7 @@ nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303
 nim_waku_metrics_port: 8008
 
-nim_waku_max_connections: 150
+nim_waku_p2p_max_connections: 150
 
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -13,6 +13,8 @@ nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303
 nim_waku_metrics_port: 8008
 
+nim_waku_max_connections: 150
+
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true
 nim_waku_websocket_cont_port: 8000

--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -74,3 +74,6 @@ nim_waku_websocket_cont_port: 8000
 #nim_waku_websocket_ssl_dir: '/etc/letsencrypt'
 #nim_waku_websocket_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/fullchain.pem'
 #nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/privkey.pem'
+
+# maximum libp2p connections
+nim_waku_max_connections: 150

--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -33,6 +33,9 @@ nim_waku_rpc_tcp_port: 8545
 nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303
 
+# maximum libp2p connections
+nim_waku_p2p_max_connections: 150
+
 # metrics are disabled by default
 nim_waku_metrics_enabled: true
 nim_waku_metrics_port: 8008
@@ -75,5 +78,3 @@ nim_waku_websocket_cont_port: 8000
 #nim_waku_websocket_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/fullchain.pem'
 #nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/privkey.pem'
 
-# maximum libp2p connections
-nim_waku_max_connections: 150

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -45,6 +45,7 @@ services:
       --persist-messages=true
       --lightpush=true
       --swap={{ nim_waku_swap_protocol_enabled | lower }}
+      --max-connections=300
 {% if nim_waku_websocket_enabled %}
       --websocket-secure-support=true
       --websocket-secure-key-path={{ nim_waku_websocket_ssl_key }}

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -45,7 +45,7 @@ services:
       --persist-messages=true
       --lightpush=true
       --swap={{ nim_waku_swap_protocol_enabled | lower }}
-      --max-connections={{ nim_waku_max_connections }}
+      --max-connections={{ nim_waku_p2p_max_connections }}
 {% if nim_waku_websocket_enabled %}
       --websocket-secure-support=true
       --websocket-secure-key-path={{ nim_waku_websocket_ssl_key }}

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -45,7 +45,7 @@ services:
       --persist-messages=true
       --lightpush=true
       --swap={{ nim_waku_swap_protocol_enabled | lower }}
-      --max-connections=300
+      --max-connections={{ nim_waku_max_connections }}
 {% if nim_waku_websocket_enabled %}
       --websocket-secure-support=true
       --websocket-secure-key-path={{ nim_waku_websocket_ssl_key }}


### PR DESCRIPTION
This PR closes https://github.com/status-im/nim-waku/issues/721

It raises the maximum number of allowed libp2p connections from `50` to `300` on the fleets.

This setting is available on both the `prod` and `test` fleets.