### PR TITLE
Lower store capacity to save resources

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -12,6 +12,8 @@ nim_waku_rpc_tcp_addr: 0.0.0.0
 
 nim_waku_p2p_max_connections: 150
 
+nim_waku_store_capacity: 10000
+
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true
 nim_waku_websocket_cont_port: 8000

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -17,6 +17,8 @@ nim_waku_metrics_port: 8008
 
 nim_waku_p2p_max_connections: 150
 
+nim_waku_store_capacity: 10000
+
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true
 nim_waku_websocket_cont_port: 8000

--- a/ansible/roles/nim-waku/defaults/main.yml
+++ b/ansible/roles/nim-waku/defaults/main.yml
@@ -36,6 +36,9 @@ nim_waku_p2p_udp_port: 30303
 # maximum libp2p connections
 nim_waku_p2p_max_connections: 150
 
+# maximum number of stored historical messages
+nim_waku_store_capacity: 10000
+
 # metrics are disabled by default
 nim_waku_metrics_enabled: true
 nim_waku_metrics_port: 8008

--- a/ansible/roles/nim-waku/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku/templates/docker-compose.yml.j2
@@ -46,6 +46,7 @@ services:
       --lightpush=true
       --swap={{ nim_waku_swap_protocol_enabled | lower }}
       --max-connections={{ nim_waku_p2p_max_connections }}
+      --store-capacity={{ nim_waku_store_capacity }}
 {% if nim_waku_websocket_enabled %}
       --websocket-secure-support=true
       --websocket-secure-key-path={{ nim_waku_websocket_ssl_key }}


### PR DESCRIPTION
This PR addresses https://github.com/status-im/nim-waku/issues/841 and https://github.com/status-im/infra-nim-waku/issues/36

It lowers store capacity on all fleet nodes to provide the temporary memory alleviation needed while implementing a more permanent solution for inefficient store queries.

The alleviation will be more effective if the available resource limits (memory, specifically) for the fleet nodes are also increased.

Details here: https://github.com/status-im/nim-waku/issues/841#issuecomment-1028851916