### PR TITLE
feat: config for sqlite-only store

### DIFF
--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -28,7 +28,7 @@ nim_waku_p2p_max_connections: 150
 
 # SQLite store
 nim_waku_sqlite_store: true
-nim_waku_sqlite_retention_time: 30.days.seconds
+nim_waku_sqlite_retention_time: '30.days.seconds'
 
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -25,7 +25,10 @@ nim_waku_rpc_tcp_port: 8545
 
 # Limits
 nim_waku_p2p_max_connections: 150
-nim_waku_store_capacity: 10000
+
+# SQLite store
+nim_waku_sqlite_store: true
+nim_waku_sqlite_retention_time: 30.days.seconds
 
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true


### PR DESCRIPTION
Configures the SQLite only store on the `wakuv2.test` fleet.

This requires `v0.10` to be deployed. Depends on the related role PR: https://github.com/status-im/infra-role-nim-waku/pull/2