### PR TITLE
chore: disable sqlite store on `wakuv2.prod`

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -24,8 +24,8 @@ nim_waku_rpc_tcp_addr: 0.0.0.0
 nim_waku_p2p_max_connections: 150
 
 # SQLite store
-nim_waku_sqlite_store: true
-nim_waku_sqlite_retention_time: 2592000 # 30 days
+nim_waku_sqlite_store: false
+# nim_waku_sqlite_retention_time: 2592000 # 30 days
 
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true


### PR DESCRIPTION
There is a known issue in v0.10 where certain store queries can slow down nodes: https://github.com/status-im/nwaku/issues/1017
A possible (at least partial) fix has been merged (https://github.com/status-im/nwaku/pull/1018) and deployed to `wakuv2.test`, but the SQLite store can be disable on `prod` in the meantime.

cc @kaiserd in case you'd rather have us keep this enabled but, say, with a shorter retention time. I think safest is to disable.