### PR TITLE
chore: enable dns discovery on wakuv2.prod fleet

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -27,6 +27,10 @@ nim_waku_p2p_max_connections: 150
 nim_waku_sqlite_store: false
 nim_waku_sqlite_retention_time: 2592000 # 30 days
 
+# DNS Discovery
+nim_waku_dns_disc_enabled: true
+nim_waku_dns_disc_url: 'enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im'
+
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true
 nim_waku_websocket_secure_enabled: true

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -16,7 +16,7 @@
 
 - name: infra-role-wireguard
   src: git@github.com:status-im/infra-role-wireguard.git
-  version: 9d8c93bc44ec123b81b9912f10e377e9b953ea5a
+  version: 544b1f0435d5ca47168236c42b6a077c44d5eb4a
   scm: git
 
 - name: consul-service
@@ -31,7 +31,7 @@
 
 - name: nim-waku
   src: git@github.com:status-im/infra-role-nim-waku.git
-  version: 47d2bd3859f3f3032aa300a44541815d65e005db
+  version: 461c0df3beb5a0b3140d6977c0b376c448bbd816
   scm: git
 
 - name: waku-peers


### PR DESCRIPTION
Enables DNS discovery as bootstrapping mechanism on `wakuv2.prod` fleet.

This was previously [successfully done for `wakuv2.test`](https://github.com/status-im/infra-nim-waku/pull/54).

Once we have confirmed that this works as expected, we could deprecate:
1) the `connect` script that runs periodically
2) peer persistence in general
