### PR TITLE
fix: new dns disc URLs after new signing key used

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -29,7 +29,7 @@ nim_waku_sqlite_retention_time: 2592000 # 30 days
 
 # DNS Discovery
 nim_waku_dns_disc_enabled: true
-nim_waku_dns_disc_url: 'enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im'
+nim_waku_dns_disc_url: 'enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im'
 
 # Enable websockets in Waku
 nim_waku_websocket_enabled: true

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -32,7 +32,7 @@ nim_waku_sqlite_retention_time: 2592000 # 30 days
 
 # DNS Discovery
 nim_waku_dns_disc_enabled: true
-nim_waku_dns_disc_url: 'enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im'
+nim_waku_dns_disc_url: 'enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im'
 
 # Ethereum client address
 nim_waku_eth_client_address: 'ws://linux-01.he-eu-hel1.nimbus.prater.wg:9547'


### PR DESCRIPTION
The keys used to sign the deployed lists for DNS discovery have changed for the wakuv2 fleets. This requires changing the DNS discovery URLs for the fleets. See [this comment](https://github.com/status-im/infra-status/issues/17#issuecomment-1250860524) for more information.