### PR TITLE
fix: adhere to simplified store config

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -24,9 +24,8 @@ nim_waku_rpc_tcp_addr: 0.0.0.0
 # Limits
 nim_waku_p2p_max_connections: 150
 
-# SQLite store
-nim_waku_sqlite_store: true
-nim_waku_sqlite_retention_time: 2592000 # 30 days
+# Store
+nim_waku_store_message_retention_policy: 'time:2592000' # 30 days
 
 # DNS Discovery
 nim_waku_dns_disc_enabled: true

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -27,9 +27,8 @@ nim_waku_rpc_tcp_port: 8545
 # Limits
 nim_waku_p2p_max_connections: 150
 
-# SQLite store
-nim_waku_sqlite_store: true
-nim_waku_sqlite_retention_time: 2592000 # 30 days
+# Store
+nim_waku_store_message_retention_policy: 'time:2592000' # 30 days
 
 # DNS Discovery
 nim_waku_dns_disc_enabled: true


### PR DESCRIPTION
This changes config for the `wakuv2` fleet according to: https://github.com/status-im/nwaku/issues/1103

Corresponding role change in: https://github.com/status-im/infra-role-nim-waku/pull/6