### PR TITLE
chore: subscribe fleets to both default and dev topics

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -12,6 +12,9 @@ nim_waku_disc_v5_enabled: true
 nim_waku_dns4_domain_name: '{{ dns_entry }}'
 nim_waku_node_key: '{{lookup("bitwarden", "fleets/wakuv2/"+stage+"/nodekeys", field=hostname)}}'
 
+# Topic configuration
+nim_waku_topics: ['/waku/2/default-waku/proto', '/waku/2/dev-waku/proto']
+
 # Ports
 nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -16,6 +16,9 @@ nim_waku_disc_v5_enabled: true
 nim_waku_dns4_domain_name: '{{ dns_entry }}'
 nim_waku_node_key: '{{lookup("bitwarden", "fleets/wakuv2/"+stage+"/nodekeys", field=hostname)}}'
 
+# Topic configuration
+nim_waku_topics: ['/waku/2/default-waku/proto', '/waku/2/dev-waku/proto']
+
 # Ports
 nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@
 
 - name: nim-waku
   src: git@github.com:status-im/infra-role-nim-waku.git
-  version: 70eef2f894cc38de1482568ed611bf07d9e095d4
+  version: af90c66627a76c5b6a08a6c13e961ea00a3b0671
   scm: git
 
 - name: waku-peers


### PR DESCRIPTION
Closes https://github.com/waku-org/pm/issues/13

Configures `wakuv2.*` fleets to be subscribed to both the default pubsub topic and a new dev topic, `/waku/2/dev-waku/proto`.

Corresponding change in the role in https://github.com/status-im/infra-role-nim-waku/pull/9, which has to be merged first.