### PR TITLE
chore: bump wakuv2 prod connection limit to 300

### DIFF
--- a/ansible/group_vars/wakuv2-prod.yml
+++ b/ansible/group_vars/wakuv2-prod.yml
@@ -25,7 +25,7 @@ nim_waku_rpc_tcp_port: 8545
 nim_waku_rpc_tcp_addr: 0.0.0.0
 
 # Limits
-nim_waku_p2p_max_connections: 150
+nim_waku_p2p_max_connections: 300
 
 # Store
 nim_waku_store_message_retention_policy: 'time:2592000' # 30 days


### PR DESCRIPTION
Based on current client requirements, it's reasonable to bring prod connection limit to something similar than the test fleet.