### PR TITLE
wakuv2-test: rln-relay testnet 3 vars

### DIFF
--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -50,11 +50,10 @@ nim_waku_websocket_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain
 nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/privkey.pem'
 
 # Waku rln-relay parameters
-nim_waku_rln_relay_content_topic: '/toy-chat/2/luzhou/proto'
+nim_waku_rln_relay_content_topic: '/toy-chat/3/mingde/proto'
 nim_waku_rln_relay_dynamic: true
-nim_waku_rln_relay_eth_account_address: '0000000000000000000000000000000000000000'
-nim_waku_rln_relay_eth_contract_address: '0x4252105670fE33D2947e8EaD304969849E64f2a6'
-nim_waku_rln_relay_eth_client_address: 'ws://linux-01.he-eu-hel1.nimbus.prater.wg:9547'
+nim_waku_rln_relay_eth_contract_address: '0x9C09146844C1326c2dBC41c451766C7138F88155'
+nim_waku_rln_relay_eth_client_address: 'ws://linux-01.he-eu-hel1.nimbus.sepolia.wg:9557'
 
 # Consul Service
 nim_waku_consul_success_before_passing: 5


### PR DESCRIPTION
This PR updates group vars for the wakuv2.test fleet, for rln-relay testnet 3 (ctx: https://github.com/waku-org/nwaku/issues/1624)
