### PR TITLE
wakuv2-test: update rln-relay params

### DIFF
--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -50,9 +50,8 @@ nim_waku_websocket_ssl_cert: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain
 nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain }}/privkey.pem'
 
 # Waku rln-relay parameters
-nim_waku_rln_relay_content_topic: '/toy-chat/3/mingde/proto'
 nim_waku_rln_relay_dynamic: true
-nim_waku_rln_relay_eth_contract_address: '0x9C09146844C1326c2dBC41c451766C7138F88155'
+nim_waku_rln_relay_eth_contract_address: '0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4'
 nim_waku_rln_relay_eth_client_address: 'ws://linux-01.ih-eu-mda1.nimbus.sepolia.wg:9557'
 nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 


### PR DESCRIPTION
Removes `nim_waku_rln_relay_content_topic` and updates `nim_waku_rln_relay_eth_contract_address`

Companion PR: https://github.com/status-im/infra-role-nim-waku/pull/13