### PR TITLE
chore: configuration update for v0.24

### DIFF
--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -29,6 +29,8 @@ nim_waku_rpc_tcp_port: 8545
 
 # Limits
 nim_waku_p2p_max_connections: 300
+nim_waku_ip_colocation_limit: 2
+nim waku_max_msg_size: 'size:1MiB'
 
 # Store
 nim_waku_store_message_retention_policy: 'size:15GB' # 25GB of data

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -30,7 +30,7 @@ nim_waku_rpc_tcp_port: 8545
 # Limits
 nim_waku_p2p_max_connections: 300
 nim_waku_ip_colocation_limit: 2
-nim waku_max_msg_size: 'size:150KiB'
+nim_waku_max_msg_size: 'size:150KiB'
 
 # Store
 nim_waku_store_message_retention_policy: 'size:15GB' # 25GB of data

--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -30,7 +30,7 @@ nim_waku_rpc_tcp_port: 8545
 # Limits
 nim_waku_p2p_max_connections: 300
 nim_waku_ip_colocation_limit: 2
-nim waku_max_msg_size: 'size:1MiB'
+nim waku_max_msg_size: 'size:150KiB'
 
 # Store
 nim_waku_store_message_retention_policy: 'size:15GB' # 25GB of data


### PR DESCRIPTION
Hello!

With nwaku v0.24 new config parameters have been added.

- `--ip-colocation-limit=2` self-explanatory, limits connections from the same IP
- `--max-msg-size="150KiB"` limits Waku messages to the specified size.

Don't merge before v0.24 is deployed :pray: 